### PR TITLE
Adjunction macro

### DIFF
--- a/2_16_equivariant_stable_category.tex
+++ b/2_16_equivariant_stable_category.tex
@@ -1,3 +1,4 @@
+%!TEX root = m392c_EHT_notes.tex
 \begin{quote}\textit{
 	``May your first talk be more peaceful.''
 }\end{quote}
@@ -15,7 +16,7 @@ That is, there's a natural transformation $\mu\colon M^2\to M$ and a unit, and $
 that the relevant diagrams commute.
 
 There are lots of examples: we've already seen that if $G$ is a group, the assignment $X\to G\times X$ is a monad.
-More generally, algebraic structres can usually be obtained monadically.
+More generally, algebraic structures can usually be obtained monadically.
 \begin{defn}
 Let $M$ be a monad on $\fC$. Then, the category $\fC[M]$ of \term{algebras over $M$} is the category whose objects
 are pairs $X\in\fC$ and structure maps $m\colon MX\to X$ satisfying associativity and unitality for $M$, and whose
@@ -28,7 +29,7 @@ The associativity diagram, for example, is
 }\]
 We require this to commute.
 
-Lots of structures are monadic, e.g.\ groups are algebras over the free group monad in $\Set$, and simiarly for
+Lots of structures are monadic, e.g.\ groups are algebras over the free group monad in $\Set$, and similarly for
 abelian groups, rings, etc. Monads very generally come from free structures in algebra; they also arise from
 adjunctions: an adjunction $F:\fC\rightleftarrows\fD: G$ defines a monad $GF$, with the structure map defined by
 the unit map $G(FG)F\to GF$. Many monads arise in this way.

--- a/macros.tex
+++ b/macros.tex
@@ -55,6 +55,33 @@ Sulyma for adding some remarks and references.}
 \newcommand{\twomorph}{\mathop{\Longrightarrow}\limits}
 
 % fancy diagram shortcuts
+
+% \lon = co\colon --- used in the inline version of \adjnctn, just being OCD about kerning
+\newcommand*\lon{%
+        \nobreak
+        \mskip6mu plus1mu
+        \mathpunct{}%
+        \nonscript
+        \mkern-\thinmuskip
+        {:}%
+        \mskip2mu
+        \relax
+}
+
+% smart adjunction macro --- displays differently in inline vs display mode
+\newcommand{\adjnctn}[4]{
+  \mathchoice{
+    \xymatrix@1{
+      #1 \ar@<1ex>[r]^-{#3} \ar@{}[r]|-{\bot} & #2 \ar@<1ex>[l]^-{#4}
+    }
+  }{
+    \xymatrix@1@C=2em{
+      \rule[-1ex]{0pt}{3.5ex}
+      #3 \colon #1 \ar@<1ex>[r] \ar@{}[r]|-{\bot} & #2 \lon #4 \ar@<1ex>[l]
+    }
+  }{}{}
+}
+
 % double adjunction
 \newcommand{\dadjnctn}[6][2em]{
   \xymatrix@1@C=#1{


### PR DESCRIPTION
First commit fixes a couple minor typos. The second one provides a slick macro for typesetting adjunctions; example usage is
````TeX
\adjnctn{X}{A}{f}{u}
````
for an adjunction $f: X \to A$, $u: A \to X$, with $f$ left adjoint to $u$. It gives different results in inline vs display mode.

I put this into `macros.tex`, but didn't change any of the adjunctions you already typeset; try it out to see if you like it.