### PR TITLE
Update 1_19_homotopy_theory_of_g_spaces.tex

### DIFF
--- a/1_19_homotopy_theory_of_g_spaces.tex
+++ b/1_19_homotopy_theory_of_g_spaces.tex
@@ -305,4 +305,5 @@ The Whitehead theorem (\cref{eqWhite}) now falls out of the general theory of mo
 Let $f\colon X\to Y$ be a weak equivalence of cofibrant-fibrant objects in a model category. Then, $f$ is a
 homotopy equivalence.
 \end{thm}
-In $\Top$ and $G\Top$, all objects are fibrant, so this is particularly applicable.
+In $\Top$ and $G\Top$, all objects are fibrant, so this is particularly applicable.\\
+{\red THIS IS FALSE:} If this were true, then point set fixed points would be homotopy fixed points, and in particular would be invariant under weak equivalences. Consider the case in which $G = C_2$ acts trivially on $*$ and by reflection through a line on $S^\infty$, then $S^\infty \to *$ is a weak equivalence, but the fixed points of $S^\infty$ is $* \sqcap *$ and the fixed points of $*$ is $*$. 


### PR DESCRIPTION
Point out false claim that all objects in G\Top are fibrant.