### PR TITLE
Fix subconjugacy relation

### DIFF
--- a/1_24_orbit_category.tex
+++ b/1_24_orbit_category.tex
@@ -16,9 +16,9 @@ That is, its objects are the spaces $G/H$, where $H\subset G$ is closed, and its
 G/K)\cong (G/K)^H$. These maps are the same thing as subconjugacy relations, i.e.\ those of the form
 \begin{equation}
 \label{subconj}
-gHg^{-1}\subseteq K,
+g^{-1}Hg\subseteq K,
 \end{equation}
-since for all $h \in H, h(gK) = gK$ if and only if $K = g^{-1}hgK$ if and only if $gHg^{-1} \subseteq K$. A
+since for all $h \in H, h(gK) = gK$ if and only if $K = g^{-1}hgK$ if and only if $g^{-1}Hg \subseteq K$. A
 $G$-map $f\colon G/H\to G/K$ is completely specified by what it does to the identity coset $f(eH) = gK$, and this
 $g$ implies the subconjugacy relation~\eqref{subconj}, since, as above, $h(gK) = gK$ for all $h \in
 H$.\index{subconjugacy}


### PR DESCRIPTION
Fix the subconjugacy relation in `1_24_orbit_category.tex`. Instead of $gHg^{-1}\subseteq K$, it should read $g^{-1}Hg\subseteq K$. I guess the former would be correct in the case of right cosets. This change corresponds to how it is presented originally (according to the nLab) in G. E. Bredon, [Equivariant Cohomology Theories](https://doi.org/10.1007/BFb0082690), § I.3, and also for example in E. Riehl, [Category Theory in Context](https://emilyriehl.github.io/files/context.pdf), Example 1.3.15.